### PR TITLE
bugfix: table list default project name missing

### DIFF
--- a/odps/tables.go
+++ b/odps/tables.go
@@ -84,7 +84,7 @@ func (ts *Tables) List(f func(*Table, error), filters ...TFilterFunc) {
 
 		for _, tableModel := range resModel.Tables {
 			table := NewTable(ts.odpsIns, ts.projectName, ts.schemaName, tableModel.Name)
-			table.model = tableModel
+			table.model.Owner = tableModel.Owner
 
 			f(table, nil)
 		}


### PR DESCRIPTION
when run `table.Load()` get request
```
GET http://service-corp.odps.aliyun-inc.com/api/projects/tables/auto_import_fence_od_dl
```

restore to old version 
```
GET http://service-corp.odps.aliyun-inc.com/api/projects/my-odps-project/tables/auto_import_fence_aoi_di1
```
<img width="497" alt="image" src="https://github.com/user-attachments/assets/17013ca4-68ef-49da-8d24-ea81cb6724d6">

<img width="483" alt="image" src="https://github.com/user-attachments/assets/9ecd74d3-50b1-49d4-8100-1a404d67c70a">
