### PR TITLE
fix: handle uncaught error during table load

### DIFF
--- a/odps/table.go
+++ b/odps/table.go
@@ -333,6 +333,10 @@ func (t *Table) Exists() (bool, error) {
 		return false, err
 	}
 
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+
 	return true, nil
 }
 


### PR DESCRIPTION
Handling uncaught error when the error is not a http error (for example due to server timeout)