### PR TITLE
fix(tea/utils): preserve raw query values in signing canonical resource

### DIFF
--- a/tea/utils/utils.go
+++ b/tea/utils/utils.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
-	"net/url"
 	"reflect"
 	"sort"
 	"strconv"
@@ -107,9 +106,9 @@ func buildCanonicalResource(resource *string, params map[string]*string) string 
 			if i > 0 {
 				builder.WriteString("&")
 			}
-			builder.WriteString(url.QueryEscape(key))
+			builder.WriteString(key)
 			if value, exists := params[key]; exists && *value != "" {
-				builder.WriteString("=" + url.QueryEscape(*value))
+				builder.WriteString("=" + *value)
 			}
 		}
 	}

--- a/tea/utils/utils_test.go
+++ b/tea/utils/utils_test.go
@@ -14,3 +14,39 @@ func TestToString(t *testing.T) {
 	t.Log(*ToString(ptr))         // hello
 	t.Log(*ToString(value))       // hello
 }
+
+func sp(s string) *string { return &s }
+
+// Opaque pagination tokens (e.g. nextPageToken) may contain reserved
+// characters such as '!'. The ODPS server builds its signing canonical
+// resource from the raw, unescaped query values, so the SDK must do the
+// same. Escaping the value here produces a signature mismatch and a 401
+// on the next page. See aliyun-odps-openapi-sdk issue #6.
+func TestBuildCanonicalResourcePreservesRawQueryValues(t *testing.T) {
+	resource := "/api/catalog/v1alpha/projects/example_project/schemas/default/tables"
+	params := map[string]*string{
+		"pageToken": sp("opaque!cursor"),
+	}
+
+	got := buildCanonicalResource(sp(resource), params)
+	want := resource + "?pageToken=opaque!cursor"
+
+	if got != want {
+		t.Errorf("buildCanonicalResource() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildCanonicalResourceSortsKeysAndOmitsEmptyValues(t *testing.T) {
+	params := map[string]*string{
+		"pageToken":   sp("a!b"),
+		"maxResults":  sp("10"),
+		"emptyFilter": sp(""),
+	}
+
+	got := buildCanonicalResource(sp("/path"), params)
+	want := "/path?emptyFilter&maxResults=10&pageToken=a!b"
+
+	if got != want {
+		t.Errorf("buildCanonicalResource() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

`tea/utils.buildCanonicalResource` runs query keys/values through `url.QueryEscape` when building the string-to-sign. But the **string-to-sign is not a URL** — the ODPS server rebuilds its canonical resource from the **raw, decoded** query values and signs those. Escaping here makes the client sign `pageToken=opaque%21cursor` while the server signs `pageToken=opaque!cursor`, so the signatures diverge and the request fails with **401 Unauthorized** whenever an opaque `pageToken` contains a reserved character such as `!`.

This surfaces on pagination: the first page (no `pageToken`) succeeds, the second page fails once the returned `nextPageToken` contains `!`.

The actual HTTP request URL is encoded by the request layer and is unaffected by this change.

## Fix

Drop `url.QueryEscape` from `buildCanonicalResource` so the canonical resource uses raw query values. This aligns the Go SDK with the **Java** (`com.aliyun.odps.utils.TeaUtils`) and **Python** (`maxcompute_tea_util`) implementations, which already sign raw values and are not affected by this bug.

## Test

Added regression tests in `tea/utils/utils_test.go`:
- `TestBuildCanonicalResourcePreservesRawQueryValues` — token `opaque!cursor` is signed verbatim.
- `TestBuildCanonicalResourceSortsKeysAndOmitsEmptyValues` — key ordering and empty-value handling preserved.

Both fail before the change (`opaque%21cursor`) and pass after. `go vet ./...` and `go test ./...` clean.

Reported in aliyun/aliyun-odps-openapi-sdk#6.